### PR TITLE
correct syntax 'ManifestStaticFilesStorage', not 'ManifestStaticFiles…

### DIFF
--- a/oc_projet13/oc_lettings_site/settings.py
+++ b/oc_projet13/oc_lettings_site/settings.py
@@ -120,4 +120,4 @@ STATIC_URL = "/static/"
 STATICFILES_DIRS = [BASE_DIR / "static"]
 # if not DEBUG:
 # STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
-STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorag'
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'


### PR DESCRIPTION
correct syntax 'ManifestStaticFilesStorage', not 'ManifestStaticFilesStorag'.