### PR TITLE
on laisse whitenoises désactiver. On force le chemin des fichiers sta…

### DIFF
--- a/oc_projet13/oc_lettings_site/settings.py
+++ b/oc_projet13/oc_lettings_site/settings.py
@@ -119,6 +119,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, "oc_projet13/staticfiles")
 STATIC_URL = "/static/"
 STATICFILES_DIRS = [BASE_DIR /"static"]
 
+
 # WHITENOISE_MANIFEST_STRICT = False
 # if not DEBUG:
 #     STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'


### PR DESCRIPTION
on laisse whitenoises désactiver. On force le chemin des fichiers statiques a servir.